### PR TITLE
Support for multiple schemas

### DIFF
--- a/lib/postgrest/builders/query_builder.rb
+++ b/lib/postgrest/builders/query_builder.rb
@@ -14,6 +14,7 @@ module Postgrest
       def select(*columns, extra_headers: {})
         columns.compact!
         columns = ['*'] if columns.length.zero?
+        extra_headers[:'Accept-Profile'] ||= schema
         request = HTTP.new(uri: uri, query: { select: columns.join(',') }, headers: headers.merge(extra_headers))
 
         FilterBuilder.new(request)
@@ -25,6 +26,7 @@ module Postgrest
 
       def upsert(values, extra_headers: {})
         extra_headers[:Prefer] ||= 'return=representation,resolution=merge-duplicates'
+        extra_headers[:'Content-Profile'] ||= schema
         request = HTTP.new(uri: uri, body: values, http_method: :post, headers: headers.merge(extra_headers))
 
         BaseBuilder.new(request)
@@ -32,6 +34,7 @@ module Postgrest
 
       def update(values, extra_headers: {})
         extra_headers[:Prefer] ||= 'return=representation'
+        extra_headers[:'Content-Profile'] ||= schema
         request = HTTP.new(uri: uri, body: values, http_method: :patch, headers: headers.merge(extra_headers))
 
         FilterBuilder.new(request)
@@ -39,6 +42,7 @@ module Postgrest
 
       def delete(extra_headers: {})
         extra_headers[:Prefer] ||= 'return=representation'
+        extra_headers[:'Content-Profile'] ||= schema
         request = HTTP.new(uri: uri, http_method: :delete, headers: headers.merge(extra_headers))
 
         FilterBuilder.new(request)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

The query builder does not set an HTTP Profile header for the client schema. This means the current behavior uses the default schema according to the PostgREST server configuration.

## What is the new behavior?

The query builder will now assign the client schema to the `Accept-Profile` and `Content-Profile` HTTP headers for each query. These values can be overridden using the `extra_headers` method parameters.

## Additional context

Relevant PostgREST documentation:
https://postgrest.org/en/stable/references/api/schemas.html#multiple-schemas
